### PR TITLE
fix(insurance-fund): render alert text in staking dialog (#97)

### DIFF
--- a/packages/web/src/components/_common/drawer-components/activity-tab.tsx
+++ b/packages/web/src/components/_common/drawer-components/activity-tab.tsx
@@ -17,7 +17,7 @@ export default function ActivityTab({ activity = [] }: { activity?: Activity[] }
 
   return (
     <Box sx={{ p: 2, pt: 0 }}>
-      <Alert severity="info" title={t('Coming soon')} />
+      <Alert severity="info">{t('Coming soon')}</Alert>
       {activity
         .sort((a, b) => b.timestamp - a.timestamp)
         .map((item) => (

--- a/packages/web/src/components/_insurance-page-components/insurance-fund-staking-dialog.tsx
+++ b/packages/web/src/components/_insurance-page-components/insurance-fund-staking-dialog.tsx
@@ -14,6 +14,7 @@ import {
   Box,
   Tabs,
   Alert,
+  AlertTitle,
   Stack,
   Dialog,
   Button,
@@ -142,19 +143,16 @@ export const Content: React.FC<ContentProps> = () => {
         </Box>
 
         {/* Content */}
-        <Alert
-          sx={{ mt: 3 }}
-          severity="warning"
-          title={
-            selectedTab == 'stake'
-              ? t(
-                  'Staked funds cannot be used as collateral. If you decide to unstake, the amount will be subject to a 13-day cool down period.'
-                )
-              : t(
-                  'Funds will be available to withdraw 13 days after making an unstake request. You can only have one pending unstake request per vault at a time. You can cancel a request at any time, noting your 13 day cool down period will restart upon any new unstake request.'
-                )
-          }
-        />
+        <Alert severity="warning" sx={{ mt: 3 }}>
+          <AlertTitle>{selectedTab === 'stake' ? t('Stake') : t('Unstake')}</AlertTitle>
+          {selectedTab === 'stake'
+            ? t(
+                'Staked funds cannot be used as collateral. If you decide to unstake, the amount will be subject to a 13-day cool-down period.'
+              )
+            : t(
+                'Funds will be available to withdraw 13 days after making an unstake request. You can only have one pending unstake request per vault at a time. You can cancel a request at any time, noting your 13-day cool-down period will restart upon any new unstake request.'
+              )}
+        </Alert>
 
         <Stack
           flexGrow={1}


### PR DESCRIPTION
<!-- READ & DELETE:
    1. Add a descriptive title `[<Tag>] <DESCRIPTION>`
    2. Update _Assignee(s)_
    3. Add _Label(s)_
    4. Set _Project(s)_
    5. Specify _Epic_ and _Iteration_ under _Project_
    6. Set _Milestone_
-->

I fixed Alert in insurance page. The problem is I dont see alerts in activity tab or other Account Drawer components.
## Issue

<!-- READ & DELETE:
     - Explain the reasoning for the PR in 1-2 sentences. Adding a screenshot is fair game.
     - If applicable: specify the ticket number below if there is a relevant issue; _keep the `-` so the full issue is referenced._
-->

- #{ISSUE_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

<!-- READ & DELETE:
- Documentation changes: only keep this if you're making documentation changes
- Unit Testing: Remove this if you didn't make code changes
-->

- [ ] **Documentation**: `<insert doc test commmand here>`; only needed if you make doc changes
- [ ] **Unit Tests**: `<insert test command here>`

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
