### PR TITLE
feat: Finish Insurance Fund staking dialog

### DIFF
--- a/packages/web/src/components/_insurance-page-components/insurance-fund-staking-dialog.tsx
+++ b/packages/web/src/components/_insurance-page-components/insurance-fund-staking-dialog.tsx
@@ -20,7 +20,6 @@ import {
   Dialog,
   Button,
   InputBase,
-  AlertTitle,
   Typography,
   DialogTitle,
   DialogContent,
@@ -158,13 +157,12 @@ export const Content: React.FC<ContentProps> = ({ queryParams }) => {
 
         {/* Content */}
         <Alert severity="warning" sx={{ mt: 3 }}>
-          <AlertTitle>{selectedTab === 'stake' ? t('Stake') : t('Unstake')}</AlertTitle>
           {selectedTab === 'stake'
             ? t(
-                'Staked funds cannot be used as collateral. If you decide to unstake, the amount will be subject to a 13-day cool-down period.'
+                'If you decide to unstake, the amount will be subject to a 13-day cool-down period.'
               )
             : t(
-                'Funds will be available to withdraw 13 days after making an unstake request. You can only have one pending unstake request per vault at a time. You can cancel a request at any time, noting your 13-day cool-down period will restart upon any new unstake request.'
+                'Funds will be available to withdraw 13 days after making an unstake request. You can only have one pending unstake request at a time. You can cancel a request at any time, noting your 13-day cool-down period will restart upon any new unstake request.'
               )}
         </Alert>
 

--- a/packages/web/src/components/_insurance-page-components/insurance-fund-staking-dialog.tsx
+++ b/packages/web/src/components/_insurance-page-components/insurance-fund-staking-dialog.tsx
@@ -3,12 +3,14 @@
 import type { InsuranceQueryParams } from '@/types/query-params';
 
 import z from 'zod';
+import { paths } from '@/routes/paths';
 import { useTranslate } from '@/locales';
-import { useInsuranceFund } from '@/hooks';
 import { useState, useEffect } from 'react';
-import { fCurrency } from '@/utils/format-number';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTokenPrice, useInsuranceFund } from '@/hooks';
 import { sanitizeAmountInput } from '@/utils/input-helpers';
+import { fCurrency, fShortenNumber } from '@/utils/format-number';
+import { constants, getCryptoIconUrl } from '@normalfinance/utils';
 import { useForm, Controller, FormProvider, useFormContext } from 'react-hook-form';
 
 import {
@@ -19,11 +21,15 @@ import {
   Stack,
   Dialog,
   Button,
+  Avatar,
+  Divider,
+  useTheme,
   InputBase,
   Typography,
   DialogTitle,
   DialogContent,
   DialogActions,
+  Link as MuiLink,
 } from '@mui/material';
 
 // ----------------------------------------------------------------------
@@ -90,6 +96,7 @@ interface ContentProps {
 }
 
 export const Content: React.FC<ContentProps> = ({ queryParams }) => {
+  const theme = useTheme();
   const { t } = useTranslate();
 
   const [selectedTab, setSelectedTab] = useState('stake'); // Default to first tab
@@ -98,7 +105,16 @@ export const Content: React.FC<ContentProps> = ({ queryParams }) => {
     setSelectedTab(newValue);
   };
 
-  const { stake, onDeposit, onRequestWithdraw } = useInsuranceFund();
+  const { data: xlmPrice, isLoading: tokenPriceLoading } = useTokenPrice(constants.XLM_ADDRESS);
+
+  const {
+    insuranceFund,
+    stake,
+    onDeposit,
+    onRequestWithdraw,
+    onCancelRequestWithdraw,
+    onWithdraw,
+  } = useInsuranceFund();
 
   const pendingUnstake = stake?.last_withdraw_request_value !== 0;
 
@@ -124,15 +140,40 @@ export const Content: React.FC<ContentProps> = ({ queryParams }) => {
       shouldValidate: true,
     });
 
-  // const fiatValue = token && amount !== '' ? Number(amount) * token.pricestatus : 0;
-  const fiatValue = 0;
+  const fiatValue = xlmPrice && amount !== '' ? Number(amount) * Number(xlmPrice.data) : 0;
 
   const handleStake = () => {
     onDeposit({ amount });
   };
 
-  const handleRequestUnstake = () => {
-    onRequestWithdraw({ amount });
+  const handleUnstakeButtonClick = () => {
+    const label = getButtonLabel();
+
+    if (label === 'Cancel unstake request') {
+      onCancelRequestWithdraw();
+    } else if (label === 'Unstake') {
+      onWithdraw();
+    } else {
+      onRequestWithdraw({ amount });
+    }
+  };
+
+  const getButtonLabel = (): string => {
+    if (!stake || !insuranceFund) return 'Failed to load data';
+
+    if (!stake.if_shares) {
+      return 'No funds to unstake';
+    }
+
+    if (stake.last_withdraw_request_shares > 0) {
+      const now = Date.now();
+      if (now - stake.last_withdraw_request_ts < insuranceFund.unstaking_period) {
+        return 'Cancel unstake request';
+      }
+      return 'Unstake';
+    }
+
+    return 'Request unstake';
   };
 
   return (
@@ -157,51 +198,190 @@ export const Content: React.FC<ContentProps> = ({ queryParams }) => {
 
         {/* Content */}
         <Alert severity="warning" sx={{ mt: 3 }}>
-          {selectedTab === 'stake'
-            ? t(
-                'If you decide to unstake, the amount will be subject to a 13-day cool-down period.'
-              )
-            : t(
+          {selectedTab === 'stake' ? (
+            t('If you decide to unstake, the amount will be subject to a 13-day cool-down period.')
+          ) : (
+            <>
+              {t(
                 'Funds will be available to withdraw 13 days after making an unstake request. You can only have one pending unstake request at a time. You can cancel a request at any time, noting your 13-day cool-down period will restart upon any new unstake request.'
-              )}
+              )}{' '}
+              <MuiLink
+                href={`${paths.docs}/developers/insurance-fund`}
+                underline="always"
+                color="secondary"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('Learn more.')}
+              </MuiLink>
+            </>
+          )}
         </Alert>
 
-        <Stack
-          flexGrow={1}
-          minWidth={0}
+        <Box
           sx={{
-            height: 1,
             display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'flex-start', // (default is fine)
             justifyContent: 'space-between',
-            mt: 3,
+            gap: 2,
           }}
         >
-          <Controller
-            name="amount"
-            control={control}
-            render={() => (
-              <InputBase
-                value={amount}
-                type="number"
-                onChange={(e) => handleChange(sanitizeAmountInput(e.target.value))}
-                placeholder="0.0"
-                inputProps={{ min: 0 }}
-                sx={{
-                  border: 'none',
-                  // 🔽  remove flexGrow so it doesn't fill the column
-                  '& input': { fontSize: 32, fontWeight: 700 },
-                }}
-              />
-            )}
-            disabled={pendingUnstake}
-          />
+          <Stack
+            flexGrow={1}
+            minWidth={0}
+            sx={{
+              height: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start', // (default is fine)
+              justifyContent: 'space-between',
+              mt: 3,
+            }}
+          >
+            <Controller
+              name="amount"
+              control={control}
+              render={() => (
+                <InputBase
+                  value={amount}
+                  type="number"
+                  onChange={(e) => handleChange(sanitizeAmountInput(e.target.value))}
+                  placeholder="0.0"
+                  inputProps={{ min: 0 }}
+                  sx={{
+                    border: 'none',
+                    // 🔽  remove flexGrow so it doesn't fill the column
+                    '& input': { fontSize: 32, fontWeight: 700 },
+                  }}
+                />
+              )}
+              disabled={pendingUnstake}
+            />
 
-          <Typography variant="body2" color="text.secondary" noWrap sx={{ mt: 0.5 }}>
-            {fiatValue > 0 ? fCurrency(fiatValue) : '$0'}
-          </Typography>
-        </Stack>
+            <Typography variant="body2" color="text.secondary" noWrap sx={{ mt: 0.5 }}>
+              {fiatValue > 0 ? fCurrency(fiatValue) : '$0'}
+            </Typography>
+          </Stack>
+
+          <Stack
+            alignItems="center"
+            direction="row"
+            spacing={1}
+            sx={{ mr: 2, borderRadius: 99, p: 1 }}
+          >
+            <Avatar src={getCryptoIconUrl('XLM')} sx={{ width: 32, height: 32 }} />
+            <Typography variant="body1" fontWeight="bold">
+              XLM
+            </Typography>
+          </Stack>
+        </Box>
+
+        {selectedTab === 'unstake' && (
+          <Box sx={{ pt: 2 }}>
+            <Divider />
+            <Box
+              sx={{
+                mt: 0,
+                px: 0,
+                width: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 1,
+                pt: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 1,
+                  px: 0,
+                }}
+              >
+                <Box
+                  sx={{
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: 1,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 1,
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 500,
+                        color: theme.palette.text.secondary,
+                        fontSize: '12px',
+                      }}
+                    >
+                      {t('Amount Staked')}
+                    </Typography>
+                  </Box>
+
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: 500,
+                      color: theme.palette.text.primary,
+                      fontSize: '12px',
+                    }}
+                  >
+                    {fShortenNumber(stake?.if_shares ?? 0)}
+                  </Typography>
+                </Box>
+
+                <Box
+                  sx={{
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: 1,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 1,
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 500,
+                        color: theme.palette.text.secondary,
+                        fontSize: '12px',
+                      }}
+                    >
+                      {t('Request for unstake')}
+                    </Typography>
+                  </Box>
+
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: 500,
+                      color: theme.palette.text.primary,
+                      fontSize: '12px',
+                    }}
+                  >
+                    {fShortenNumber(stake?.last_withdraw_request_shares ?? 0)}
+                  </Typography>
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+        )}
       </DialogContent>
 
       <DialogActions>
@@ -214,11 +394,11 @@ export const Content: React.FC<ContentProps> = ({ queryParams }) => {
           <Button
             variant="contained"
             color="secondary"
-            onClick={handleRequestUnstake}
+            onClick={handleUnstakeButtonClick}
             autoFocus
             disabled={pendingUnstake}
           >
-            {t('Request unstake')}
+            {getButtonLabel()}
           </Button>
         )}
       </DialogActions>

--- a/packages/web/src/hooks/stellar/tokens/index.ts
+++ b/packages/web/src/hooks/stellar/tokens/index.ts
@@ -1,4 +1,5 @@
 export * from './utils';
 export * from './use-api-tokens';
 export * from './use-all-tokens';
+export * from './use-token-price';
 export * from './use-featured-tokens';

--- a/packages/web/src/hooks/stellar/tokens/use-token-price.ts
+++ b/packages/web/src/hooks/stellar/tokens/use-token-price.ts
@@ -1,0 +1,37 @@
+import useSWRImmutable from 'swr/immutable';
+import { getOraclePrice } from '@/lib/oracle';
+import { usePersistStore } from '@normalfinance/state';
+
+interface FetchTokenBalanceProps {
+  oracleAddress: string;
+  tokenAddress: string;
+}
+
+const fetchOraclePrice = async ({ oracleAddress, tokenAddress }: FetchTokenBalanceProps) => {
+  const { price, timestamp } = await getOraclePrice(oracleAddress, tokenAddress);
+
+  if (price === null) {
+    throw new Error('Failed to fetch price');
+  }
+
+  return { data: price, validAccount: true };
+};
+
+export const useTokenPrice = (tokenAddress: string | null) => {
+  const store = usePersistStore();
+  const address = store.wallet.address;
+
+  const canFetch = !!(address && tokenAddress);
+
+  const { data, isLoading, mutate, error } = useSWRImmutable(
+    canFetch ? ['token-price', tokenAddress, address] : null,
+    ([, tokenAddr, addr]) => fetchOraclePrice({ oracleAddress: '', tokenAddress: tokenAddr })
+  );
+
+  return {
+    data: canFetch ? data : null,
+    isLoading: canFetch ? isLoading : false,
+    mutate,
+    isError: canFetch ? error : null,
+  };
+};


### PR DESCRIPTION
## Summary

This PR completes the InsuranceFundStakingDialog component. Changes include:
- Adding XLM icon and symbol to amount input 
- Fetching XLM token price to show fiatValue
- Updating alert text and adding learn more link
- Adding AmountStaked and Request for Unstake values to display
- Rendering dynamic button label based on user stake status along with dynamic onSubmit button action to the correct stake management action

## Issue

https://github.com/normalfinance/normal-v1-interface/issues/118

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

<!-- READ & DELETE:
- Documentation changes: only keep this if you're making documentation changes
- Unit Testing: Remove this if you didn't make code changes
-->

- [ ] **Documentation**: `<insert doc test commmand here>`; only needed if you make doc changes
- [ ] **Unit Tests**: `<insert test command here>`

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
